### PR TITLE
ensure unique filepaths per project

### DIFF
--- a/config/defaults/mysql_schema_setup.sql
+++ b/config/defaults/mysql_schema_setup.sql
@@ -2,11 +2,11 @@ USE `cc`;
 # USE `testing`;
 
 
--- MySQL dump 10.13  Distrib 5.7.15, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.16, for Linux (x86_64)
 --
 -- Host: localhost    Database: cc
 -- ------------------------------------------------------
--- Server version	5.7.15
+-- Server version	5.7.16
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -30,11 +30,12 @@ CREATE TABLE `File` (
   `FileID` bigint(20) NOT NULL AUTO_INCREMENT,
   `Creator` varchar(25) COLLATE utf8_unicode_ci NOT NULL,
   `CreationDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `RelativePath` varchar(2083) COLLATE utf8_unicode_ci NOT NULL,
+  `RelativePath` varchar(970) COLLATE utf8_unicode_ci NOT NULL,
   `ProjectID` bigint(20) NOT NULL,
   `Filename` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`FileID`),
   UNIQUE KEY `FileID_UNIQUE` (`FileID`),
+  UNIQUE KEY `unique_location` (`ProjectID`,`RelativePath`,`Filename`),
   KEY `fk_File_Username_idx` (`Creator`),
   KEY `fk_File_ProjectID_idx` (`ProjectID`),
   CONSTRAINT `fk_File_ProjectID` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`) ON DELETE NO ACTION ON UPDATE CASCADE,

--- a/config/defaults/mysql_testing_schema_setup.sql
+++ b/config/defaults/mysql_testing_schema_setup.sql
@@ -2,11 +2,11 @@
 USE `testing`;
 
 
--- MySQL dump 10.13  Distrib 5.7.15, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.16, for Linux (x86_64)
 --
 -- Host: localhost    Database: testing
 -- ------------------------------------------------------
--- Server version	5.7.15
+-- Server version	5.7.16
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -30,11 +30,12 @@ CREATE TABLE `File` (
   `FileID` bigint(20) NOT NULL AUTO_INCREMENT,
   `Creator` varchar(25) COLLATE utf8_unicode_ci NOT NULL,
   `CreationDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `RelativePath` varchar(2083) COLLATE utf8_unicode_ci NOT NULL,
+  `RelativePath` varchar(970) COLLATE utf8_unicode_ci NOT NULL,
   `ProjectID` bigint(20) NOT NULL,
   `Filename` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`FileID`),
   UNIQUE KEY `FileID_UNIQUE` (`FileID`),
+  UNIQUE KEY `unique_location` (`ProjectID`,`RelativePath`,`Filename`),
   KEY `fk_File_Username_idx` (`Creator`),
   KEY `fk_File_ProjectID_idx` (`ProjectID`),
   CONSTRAINT `fk_File_ProjectID` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`) ON DELETE NO ACTION ON UPDATE CASCADE,

--- a/config/defaults/mysql_testing_schema_setup.sql
+++ b/config/defaults/mysql_testing_schema_setup.sql
@@ -6,7 +6,7 @@ USE `testing`;
 --
 -- Host: localhost    Database: testing
 -- ------------------------------------------------------
--- Server version	5.7.16
+-- Server version	5.7.15
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -30,12 +30,11 @@ CREATE TABLE `File` (
   `FileID` bigint(20) NOT NULL AUTO_INCREMENT,
   `Creator` varchar(25) COLLATE utf8_unicode_ci NOT NULL,
   `CreationDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `RelativePath` varchar(970) COLLATE utf8_unicode_ci NOT NULL,
+  `RelativePath` varchar(2083) COLLATE utf8_unicode_ci NOT NULL,
   `ProjectID` bigint(20) NOT NULL,
   `Filename` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`FileID`),
   UNIQUE KEY `FileID_UNIQUE` (`FileID`),
-  UNIQUE KEY `unique_location` (`ProjectID`,`RelativePath`,`Filename`),
   KEY `fk_File_Username_idx` (`Creator`),
   KEY `fk_File_ProjectID_idx` (`ProjectID`),
   CONSTRAINT `fk_File_ProjectID` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`) ON DELETE NO ACTION ON UPDATE CASCADE,
@@ -141,12 +140,22 @@ CREATE TABLE `User` (
 /*!50003 SET sql_mode              = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION' */ ;
 DELIMITER ;;
 CREATE DEFINER=`root`@`localhost` PROCEDURE `file_create`(IN username varchar(25), IN filename varchar(50), IN relativePath varchar(2083), IN projectID bigint(20))
-  BEGIN
-    INSERT INTO `File`
-    (Creator, RelativePath, ProjectID, Filename)
-    VALUES (username, relativePath, projectID, filename);
-    SELECT LAST_INSERT_ID();
-  END ;;
+BEGIN
+  IF ( NOT EXISTS ( SELECT `File`.`FileID`
+          FROM `File`
+          WHERE `File`.`ProjectID` =  projectID AND `File`.`RelativePath` = relativePath AND `File`.`Filename` = filename ) ) THEN
+      BEGIN
+        INSERT INTO `File`
+        (Creator, RelativePath, ProjectID, Filename)
+        VALUES (username, relativePath, projectID, filename);
+        SELECT LAST_INSERT_ID();
+      END;
+    ELSE
+      BEGIN
+        SELECT null;
+      END;
+    END IF;
+END ;;
 DELIMITER ;
 /*!50003 SET sql_mode              = @saved_sql_mode */ ;
 /*!50003 SET character_set_client  = @saved_cs_client */ ;
@@ -511,7 +520,7 @@ DELIMITER ;
 DELIMITER ;;
 CREATE DEFINER=`root`@`localhost` PROCEDURE `user_project_permission`(username varchar(25), projectID bigint(20))
 BEGIN
-	SELECT Permissions.PermissionLevel
+  SELECT Permissions.PermissionLevel
     FROM Permissions
     WHERE Permissions.Username = username and Permissions.ProjectID = projectID
     UNION

--- a/modules/datahandling/filerequests.go
+++ b/modules/datahandling/filerequests.go
@@ -77,12 +77,12 @@ func (f fileCreateRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusUnauthorized, f.Tag)}}, nil
 	}
 
-	_, err = db.FileWrite(f.RelativePath, f.Name, f.ProjectID, f.FileBytes)
+	fileID, err := db.MySQLFileCreate(f.SenderID, f.Name, f.RelativePath, f.ProjectID)
 	if err != nil {
 		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusFail, f.Tag)}}, err
 	}
 
-	fileID, err := db.MySQLFileCreate(f.SenderID, f.Name, f.RelativePath, f.ProjectID)
+	_, err = db.FileWrite(f.RelativePath, f.Name, f.ProjectID, f.FileBytes)
 	if err != nil {
 		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusFail, f.Tag)}}, err
 	}

--- a/modules/datahandling/messages/Responses.go
+++ b/modules/datahandling/messages/Responses.go
@@ -62,14 +62,14 @@ const StatusNotFound int = 404
 // StatusVersionOutOfDate represents a state in which the client has an outdated version of the resource
 const StatusVersionOutOfDate int = 409 // (409 = conflict)
 
-// StatusPartialfail represents a partial failure in processing the request
-const StatusPartialfail int = 499
+// StatusPartialFail represents a partial failure in processing the request
+const StatusPartialFail int = 499
 
-// StatusServfail represents an internal failure in processing.
-const StatusServfail int = 500
+// StatusServFail represents an internal failure in processing.
+const StatusServFail int = 500
 
 // StatusUnimplemented represents a called method that has not yet been implemented
 const StatusUnimplemented = 501
 
-// StatusServpartialfail represents an internal failure in processing part of the request.
-const StatusServpartialfail int = 599
+// StatusServPartialFail represents an internal failure in processing part of the request.
+const StatusServPartialFail int = 599

--- a/modules/datahandling/projectrequests.go
+++ b/modules/datahandling/projectrequests.go
@@ -83,7 +83,7 @@ func (p projectCreateRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 		//if err == project already exists {
 		// TODO(shapiro): implement a specific error for this on the mysql.go side
 		//}
-		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServfail, p.Tag)}}, nil
+		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServFail, p.Tag)}}, nil
 	}
 
 	res := messages.Response{
@@ -124,7 +124,7 @@ func (p projectRenameRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 
 	err = db.MySQLProjectRename(p.ProjectID, p.NewName)
 	if err != nil {
-		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServfail, p.Tag)}}, err
+		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServFail, p.Tag)}}, err
 	}
 
 	res := messages.NewEmptyResponse(messages.StatusSuccess, p.Tag)
@@ -192,7 +192,7 @@ func (p projectGrantPermissionsRequest) process(db dbfs.DBFS) ([]dhClosure, erro
 
 	ownerPerm, err := config.PermissionByLabel("owner")
 	if err != nil {
-		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServfail, p.Tag)}}, nil
+		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServFail, p.Tag)}}, nil
 	}
 
 	if requestPerm.Level == ownerPerm.Level {
@@ -202,7 +202,7 @@ func (p projectGrantPermissionsRequest) process(db dbfs.DBFS) ([]dhClosure, erro
 
 	err = db.MySQLProjectGrantPermission(p.ProjectID, p.GrantUsername, p.PermissionLevel, p.SenderID)
 	if err != nil {
-		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServfail, p.Tag)}}, err
+		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServFail, p.Tag)}}, err
 	}
 
 	res := messages.NewEmptyResponse(messages.StatusSuccess, p.Tag)
@@ -258,7 +258,7 @@ func (p projectRevokePermissionsRequest) process(db dbfs.DBFS) ([]dhClosure, err
 		if err == dbfs.ErrNoDbChange {
 			ownerPerm, err := config.PermissionByLabel("owner")
 			if err != nil {
-				return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServfail, p.Tag)}}, nil
+				return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServFail, p.Tag)}}, nil
 			}
 
 			_, permissions, err := db.MySQLProjectLookup(p.ProjectID, p.SenderID)
@@ -277,7 +277,7 @@ func (p projectRevokePermissionsRequest) process(db dbfs.DBFS) ([]dhClosure, err
 				}
 			}
 		}
-		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServfail, p.Tag)}}, err
+		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServFail, p.Tag)}}, err
 	}
 
 	res := messages.NewEmptyResponse(messages.StatusSuccess, p.Tag)
@@ -391,7 +391,7 @@ func (p projectLookupRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 			return []dhClosure{toSenderClosure{msg: res}}, nil
 		}
 		res := messages.Response{
-			Status: messages.StatusPartialfail,
+			Status: messages.StatusPartialFail,
 			Tag:    p.Tag,
 			Data: struct {
 				Projects []projectLookupResult
@@ -515,7 +515,7 @@ func (p projectGetFilesRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 			return []dhClosure{toSenderClosure{msg: res}}, nil
 		}
 		res := messages.Response{
-			Status: messages.StatusPartialfail,
+			Status: messages.StatusPartialFail,
 			Tag:    p.Tag,
 			Data: struct {
 				Files []fileLookupResult
@@ -618,7 +618,7 @@ func (p projectDeleteRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 		if err == dbfs.ErrNoDbChange {
 			return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusFail, p.Tag)}}, err
 		}
-		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServfail, p.Tag)}}, err
+		return []dhClosure{toSenderClosure{msg: messages.NewEmptyResponse(messages.StatusServFail, p.Tag)}}, err
 
 	}
 

--- a/modules/datahandling/userrequests.go
+++ b/modules/datahandling/userrequests.go
@@ -199,7 +199,7 @@ func (f userLookupRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 		// return what we can but
 		// tell the client whatever they don't get back failed
 		res := messages.Response{
-			Status: messages.StatusPartialfail,
+			Status: messages.StatusPartialFail,
 			Tag:    f.Tag,
 			Data: struct {
 				Users []dbfs.UserMeta
@@ -259,7 +259,7 @@ func (f userProjectsRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 
 	if errOut != nil {
 		res := messages.Response{
-			Status: messages.StatusPartialfail,
+			Status: messages.StatusPartialFail,
 			Tag:    f.Tag,
 			Data: struct {
 				Projects []projectLookupResult

--- a/modules/dbfs/filestorage.go
+++ b/modules/dbfs/filestorage.go
@@ -17,7 +17,7 @@ var filePathSeparator = strconv.QuoteRune(os.PathSeparator)[1:2]
 // FileWrite writes the file with the given bytes to a calculated path, and
 // returns that path so it can be put in MySQL
 func (di *DatabaseImpl) FileWrite(relpath string, filename string, projectID int64, raw []byte) (string, error) {
-	relFilePath, err := di.cleanPath(relpath, filename, projectID)
+	relFilePath, err := di.getFilepath(relpath, filename, projectID)
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +37,7 @@ func (di *DatabaseImpl) FileWrite(relpath string, filename string, projectID int
 // FileDelete deletes the file with the given metadata from the file system
 // Couple this with dbfs.MySQLFileDelete and dbfs.CBDeleteFile
 func (di *DatabaseImpl) FileDelete(relpath string, filename string, projectID int64) error {
-	relFilePath, err := di.cleanPath(relpath, filename, projectID)
+	relFilePath, err := di.getFilepath(relpath, filename, projectID)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (di *DatabaseImpl) FileDelete(relpath string, filename string, projectID in
 
 // FileRead returns the project file from the calculated location on the disk
 func (di *DatabaseImpl) FileRead(relpath string, filename string, projectID int64) (*[]byte, error) {
-	relFilePath, err := di.cleanPath(relpath, filename, projectID)
+	relFilePath, err := di.getFilepath(relpath, filename, projectID)
 	if err != nil {
 		return new([]byte), err
 	}
@@ -58,11 +58,11 @@ func (di *DatabaseImpl) FileRead(relpath string, filename string, projectID int6
 
 // FileMove moves a file form the starting path to the end path
 func (di *DatabaseImpl) FileMove(startRelpath string, startFilename string, endRelpath string, endFilename string, projectID int64) error {
-	startRelFilePath, err := di.cleanPath(startRelpath, startFilename, projectID)
+	startRelFilePath, err := di.getFilepath(startRelpath, startFilename, projectID)
 	if err != nil {
 		return err
 	}
-	endRelFilePath, err := di.cleanPath(endRelpath, endFilename, projectID)
+	endRelFilePath, err := di.getFilepath(endRelpath, endFilename, projectID)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (di *DatabaseImpl) FileMove(startRelpath string, startFilename string, endR
 
 // returns the swap file contents and any error
 func (di *DatabaseImpl) makeSwp(relpath string, filename string, projectID int64) ([]byte, error) {
-	relFilePath, err := di.cleanPath(relpath, filename, projectID)
+	relFilePath, err := di.getFilepath(relpath, filename, projectID)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -98,7 +98,7 @@ func (di *DatabaseImpl) makeSwp(relpath string, filename string, projectID int64
 
 // swapRead returns the swap file from the calculated location on the disk
 func (di *DatabaseImpl) swapRead(relpath string, filename string, projectID int64) (*[]byte, error) {
-	relFilePath, err := di.cleanPath(relpath, filename, projectID)
+	relFilePath, err := di.getFilepath(relpath, filename, projectID)
 	if err != nil {
 		return new([]byte), err
 	}
@@ -110,7 +110,7 @@ func (di *DatabaseImpl) swapRead(relpath string, filename string, projectID int6
 
 // FileWriteToSwap writes the swapfile for the file with the given info
 func (di *DatabaseImpl) FileWriteToSwap(meta FileMeta, raw []byte) error {
-	relFilePath, err := di.cleanPath(meta.RelativePath, meta.Filename, meta.ProjectID)
+	relFilePath, err := di.getFilepath(meta.RelativePath, meta.Filename, meta.ProjectID)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (di *DatabaseImpl) FileWriteToSwap(meta FileMeta, raw []byte) error {
 
 // returns any error
 func (di *DatabaseImpl) deleteSwp(relpath string, filename string, projectID int64) error {
-	relFilePath, err := di.cleanPath(relpath, filename, projectID)
+	relFilePath, err := di.getFilepath(relpath, filename, projectID)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (di *DatabaseImpl) deleteSwp(relpath string, filename string, projectID int
 
 // swaps the swapfile to the location of the real file
 func (di *DatabaseImpl) swapSwp(relpath string, filename string, projectID int64) error {
-	relFilePath, err := di.cleanPath(relpath, filename, projectID)
+	relFilePath, err := di.getFilepath(relpath, filename, projectID)
 	if err != nil {
 		return err
 	}
@@ -182,11 +182,11 @@ func (di *DatabaseImpl) fileCopy(src string, dst string) error {
 }
 
 // cleanPath cleans the relative filepath given and verifies that the filename is safe
-func (di *DatabaseImpl) cleanPath(relativePath string, filename string, projectID int64) (string, error) {
+func (di *DatabaseImpl) getFilepath(relpath string, filename string, projectID int64) (string, error) {
 	if strings.Contains(filename, filePathSeparator) {
 		return "", ErrMaliciousRequest
 	}
-	cleanPath := filepath.Clean(relativePath)
+	cleanPath := filepath.Clean(relpath)
 	if strings.HasPrefix(cleanPath, "..") {
 		return "", ErrMaliciousRequest
 	}

--- a/modules/dbfs/mysql.go
+++ b/modules/dbfs/mysql.go
@@ -85,12 +85,12 @@ STORED PROCEDURES
 
 // MySQLUserRegister registers a new user in MySQL
 func (di *DatabaseImpl) MySQLUserRegister(user UserMeta) error {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL user_register(?,?,?,?,?)", user.Username, user.Password, user.Email, user.FirstName, user.LastName)
+	result, err := mysqlConn.db.Exec("CALL user_register(?,?,?,?,?)", user.Username, user.Password, user.Email, user.FirstName, user.LastName)
 	if err != nil {
 		return err
 	}
@@ -105,12 +105,12 @@ func (di *DatabaseImpl) MySQLUserRegister(user UserMeta) error {
 
 // MySQLUserGetPass is used to get the key and hash of a stored password to verify that a value is correct
 func (di *DatabaseImpl) MySQLUserGetPass(username string) (password string, err error) {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return "", err
 	}
 
-	rows, err := mysql.db.Query("CALL user_get_password(?)", username)
+	rows, err := mysqlConn.db.Query("CALL user_get_password(?)", username)
 	if err != nil {
 		return "", err
 	}
@@ -129,12 +129,12 @@ func (di *DatabaseImpl) MySQLUserGetPass(username string) (password string, err 
 
 // MySQLUserDelete deletes a user from MySQL
 func (di *DatabaseImpl) MySQLUserDelete(username string) ([]int64, error) {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return []int64{}, err
 	}
 
-	rows, err := mysql.db.Query("Call user_get_projectids(?)", username)
+	rows, err := mysqlConn.db.Query("Call user_get_projectids(?)", username)
 
 	var projectIDs []int64
 	for rows.Next() {
@@ -149,7 +149,7 @@ func (di *DatabaseImpl) MySQLUserDelete(username string) ([]int64, error) {
 		projectIDs = append(projectIDs, projectID)
 	}
 
-	result, err := mysql.db.Exec("CALL user_delete(?)", username)
+	result, err := mysqlConn.db.Exec("CALL user_delete(?)", username)
 	if err != nil {
 		return []int64{}, err
 	}
@@ -164,12 +164,12 @@ func (di *DatabaseImpl) MySQLUserDelete(username string) ([]int64, error) {
 
 // MySQLUserLookup returns user information about a user with the username 'username'
 func (di *DatabaseImpl) MySQLUserLookup(username string) (user UserMeta, err error) {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return user, err
 	}
 
-	rows, err := mysql.db.Query("CALL user_lookup(?)", username)
+	rows, err := mysqlConn.db.Query("CALL user_lookup(?)", username)
 	if err != nil {
 		return user, err
 	}
@@ -190,12 +190,12 @@ func (di *DatabaseImpl) MySQLUserLookup(username string) (user UserMeta, err err
 
 // MySQLUserProjects returns the projectID, the project name, and the permission level the user `username` has on that project
 func (di *DatabaseImpl) MySQLUserProjects(username string) ([]ProjectMeta, error) {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err := mysql.db.Query("CALL user_projects(?)", username)
+	rows, err := mysqlConn.db.Query("CALL user_projects(?)", username)
 	if err != nil {
 		return nil, err
 	}
@@ -216,12 +216,12 @@ func (di *DatabaseImpl) MySQLUserProjects(username string) ([]ProjectMeta, error
 
 // MySQLProjectCreate create a new project in MySQL
 func (di *DatabaseImpl) MySQLProjectCreate(username string, projectName string) (projectID int64, err error) {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return -1, err
 	}
 
-	rows, err := mysql.db.Query("CALL project_create(?,?)", projectName, username)
+	rows, err := mysqlConn.db.Query("CALL project_create(?,?)", projectName, username)
 	if err != nil {
 		return -1, err
 	}
@@ -237,12 +237,12 @@ func (di *DatabaseImpl) MySQLProjectCreate(username string, projectName string) 
 
 // MySQLProjectDelete deletes a project from MySQL
 func (di *DatabaseImpl) MySQLProjectDelete(projectID int64, senderID string) error {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL project_delete(?,?)", projectID, senderID)
+	result, err := mysqlConn.db.Exec("CALL project_delete(?,?)", projectID, senderID)
 	if err != nil {
 		return err
 	}
@@ -256,12 +256,12 @@ func (di *DatabaseImpl) MySQLProjectDelete(projectID int64, senderID string) err
 
 // MySQLProjectGetFiles returns the Files from the project with projectID = projectID
 func (di *DatabaseImpl) MySQLProjectGetFiles(projectID int64) (files []FileMeta, err error) {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err := mysql.db.Query("CALL project_get_files(?)", projectID)
+	rows, err := mysqlConn.db.Query("CALL project_get_files(?)", projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -282,12 +282,12 @@ func (di *DatabaseImpl) MySQLProjectGetFiles(projectID int64) (files []FileMeta,
 
 // MySQLProjectGrantPermission gives the user `grantUsername` the permission `permissionLevel` on project `projectID`
 func (di *DatabaseImpl) MySQLProjectGrantPermission(projectID int64, grantUsername string, permissionLevel int8, grantedByUsername string) error {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL project_grant_permissions(?, ?, ?, ?)", projectID, grantUsername, permissionLevel, grantedByUsername)
+	result, err := mysqlConn.db.Exec("CALL project_grant_permissions(?, ?, ?, ?)", projectID, grantUsername, permissionLevel, grantedByUsername)
 	if err != nil {
 		return err
 	}
@@ -302,12 +302,12 @@ func (di *DatabaseImpl) MySQLProjectGrantPermission(projectID int64, grantUserna
 // MySQLProjectRevokePermission removes revokeUsername's permissions from the project
 // DOES NOT WORK FOR OWNER (which is kinda a good thing)
 func (di *DatabaseImpl) MySQLProjectRevokePermission(projectID int64, revokeUsername string, revokedByUsername string) error {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL project_revoke_permissions(?, ?)", projectID, revokeUsername)
+	result, err := mysqlConn.db.Exec("CALL project_revoke_permissions(?, ?)", projectID, revokeUsername)
 	if err != nil {
 		return err
 	}
@@ -321,12 +321,12 @@ func (di *DatabaseImpl) MySQLProjectRevokePermission(projectID int64, revokeUser
 
 // MySQLUserProjectPermissionLookup returns the permission level of `username` on the project with the given projectID
 func (di *DatabaseImpl) MySQLUserProjectPermissionLookup(projectID int64, username string) (int8, error) {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return 0, err
 	}
 
-	rows, err := mysql.db.Query("CALL user_project_permission(?, ?)", username, projectID)
+	rows, err := mysqlConn.db.Query("CALL user_project_permission(?, ?)", username, projectID)
 	if err != nil {
 		return 0, err
 	}
@@ -349,12 +349,12 @@ func (di *DatabaseImpl) MySQLUserProjectPermissionLookup(projectID int64, userna
 
 // MySQLProjectRename allows for you to rename projects
 func (di *DatabaseImpl) MySQLProjectRename(projectID int64, newName string) error {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL project_rename(?, ?)", projectID, newName)
+	result, err := mysqlConn.db.Exec("CALL project_rename(?, ?)", projectID, newName)
 	if err != nil {
 		return err
 	}
@@ -378,14 +378,14 @@ func (di *DatabaseImpl) MySQLProjectRename(projectID int64, newName string) erro
 // http://stackoverflow.com/a/8150183 <- preferred if we switch b/c FIND_IN_SET doesn't use indexes
 func (di *DatabaseImpl) MySQLProjectLookup(projectID int64, username string) (name string, permissions map[string]ProjectPermission, err error) {
 	permissions = make(map[string](ProjectPermission))
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return "", permissions, err
 	}
 
 	// TODO (optional): un-hardcode '10' as the owner constant in the MySQL ProjectLookup stored proc
 
-	rows, err := mysql.db.Query("CALL project_lookup(?)", projectID)
+	rows, err := mysqlConn.db.Query("CALL project_lookup(?)", projectID)
 	if err != nil {
 		return "", permissions, err
 	}
@@ -415,25 +415,28 @@ func (di *DatabaseImpl) MySQLProjectLookup(projectID int64, username string) (na
 }
 
 // MySQLFileCreate create a new file in MySQL
-func (di *DatabaseImpl) MySQLFileCreate(username string, filename string, relativePath string, projectID int64) (fileID int64, err error) {
-	if strings.Contains(filename, filePathSeparator) {
+func (di *DatabaseImpl) MySQLFileCreate(username string, filename string, relativePath string, projectID int64) (int64, error) {
+	filename = filepath.Clean(filename)
+	if strings.Contains(filename, filePathSeparator) || strings.Contains(filename, "..") {
 		return -1, ErrMaliciousRequest
 	}
 
-	filepathClean := filepath.Clean(relativePath)
-	if strings.HasPrefix(filepathClean, "..") {
+	relativePath = filepath.Clean(relativePath)
+	if strings.HasPrefix(relativePath, "..") {
 		return -1, ErrMaliciousRequest
 	}
 
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return -1, err
 	}
 
-	rows, err := mysql.db.Query("CALL file_create(?,?,?,?)", username, filename, filepathClean, projectID)
+	rows, err := mysqlConn.db.Query("CALL file_create(?,?,?,?)", username, filename, relativePath, projectID)
 	if err != nil {
 		return -1, err
 	}
+
+	var fileID int64
 	for rows.Next() {
 		err = rows.Scan(&fileID)
 		if err != nil {
@@ -447,12 +450,12 @@ func (di *DatabaseImpl) MySQLFileCreate(username string, filename string, relati
 // MySQLFileDelete deletes a file from the MySQL database
 // this does not delete the actual file
 func (di *DatabaseImpl) MySQLFileDelete(fileID int64) error {
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL file_delete(?)", fileID)
+	result, err := mysqlConn.db.Exec("CALL file_delete(?)", fileID)
 	if err != nil {
 		return err
 	}
@@ -471,12 +474,12 @@ func (di *DatabaseImpl) MySQLFileMove(fileID int64, newPath string) error {
 		return ErrMaliciousRequest
 	}
 
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL file_move(?, ?)", fileID, newPathClean)
+	result, err := mysqlConn.db.Exec("CALL file_move(?, ?)", fileID, newPathClean)
 	if err != nil {
 		return err
 	}
@@ -494,12 +497,12 @@ func (di *DatabaseImpl) MySQLFileRename(fileID int64, newName string) error {
 		return ErrMaliciousRequest
 	}
 
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return err
 	}
 
-	result, err := mysql.db.Exec("CALL file_rename(?, ?)", fileID, newName)
+	result, err := mysqlConn.db.Exec("CALL file_rename(?, ?)", fileID, newName)
 	if err != nil {
 		return err
 	}
@@ -514,12 +517,12 @@ func (di *DatabaseImpl) MySQLFileRename(fileID int64, newName string) error {
 // MySQLFileGetInfo returns the meta data about the given file
 func (di *DatabaseImpl) MySQLFileGetInfo(fileID int64) (FileMeta, error) {
 	file := FileMeta{}
-	mysql, err := di.getMySQLConn()
+	mysqlConn, err := di.getMySQLConn()
 	if err != nil {
 		return file, err
 	}
 
-	rows, err := mysql.db.Query("CALL file_get_info(?)", fileID)
+	rows, err := mysqlConn.db.Query("CALL file_get_info(?)", fileID)
 	if err != nil {
 		return file, err
 	}


### PR DESCRIPTION
previously we could call `File.Create` for the same file multiple times since the paths + filenames didn't have to be unique