### PR TITLE
Modify fileChangeResponse to return accepted changes in response

### DIFF
--- a/modules/datahandling/filerequests.go
+++ b/modules/datahandling/filerequests.go
@@ -328,9 +328,11 @@ func (f fileChangeRequest) process(db dbfs.DBFS) ([]dhClosure, error) {
 		Tag:    f.Tag,
 		Data: struct {
 			FileVersion    int64
+			Changes        []string
 			MissingPatches []string
 		}{
 			FileVersion:    version,
+			Changes:        changes,
 			MissingPatches: missing,
 		},
 	}.Wrap()

--- a/modules/patching/diff.go
+++ b/modules/patching/diff.go
@@ -166,7 +166,7 @@ func (diff *Diff) subChangesEndingAt(end int) *Diff {
 	return NewDiff(diff.Insertion, diff.StartIndex, diff.Changes[:end])
 }
 
-func (diff *Diff) transform(others Diffs) Diffs {
+func (diff *Diff) transform(others Diffs, othersHavePrecedence bool) Diffs {
 	intermediateDiffs := Diffs{}
 	intermediateDiffs = append(intermediateDiffs, diff)
 
@@ -193,8 +193,15 @@ func (diff *Diff) transform(others Diffs) Diffs {
 			// CASE 2: IndexA = IndexB
 			case other.StartIndex == current.StartIndex:
 				switch {
-				// CASES 2a, 2b: Ins - Ins, Ins - Rmv
-				case other.Insertion && current.Insertion, other.Insertion && !current.Insertion:
+				// CASES 2a: Ins - Ins
+				case other.Insertion && current.Insertion:
+					if othersHavePrecedence {
+						newIntermediateDiffs = doTransform(transformType2, newIntermediateDiffs, current, other)
+					} else {
+						newIntermediateDiffs = doTransform(transformType1, newIntermediateDiffs, current, other)
+					}
+				// CASES 2b: Ins - Rmv
+				case other.Insertion && !current.Insertion:
 					newIntermediateDiffs = doTransform(transformType2, newIntermediateDiffs, current, other)
 				// CASE 2c: Rmv - Ins
 				// Do nothing

--- a/modules/patching/diff_test.go
+++ b/modules/patching/diff_test.go
@@ -139,7 +139,7 @@ func TestDiff_Transform1A(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "8:+4:str2", result[0].String())
 
@@ -147,7 +147,7 @@ func TestDiff_Transform1A(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("1:+4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "5:+4:str2", result[0].String())
 }
@@ -157,7 +157,7 @@ func TestDiff_Transform1B(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "8:-4:str2", result[0].String())
 
@@ -165,7 +165,7 @@ func TestDiff_Transform1B(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("1:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "5:-4:str2", result[0].String())
 }
@@ -176,7 +176,7 @@ func TestDiff_Transform1C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "2:+4:str2", result[0].String())
 
@@ -184,7 +184,7 @@ func TestDiff_Transform1C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "2:+4:str2", result[0].String())
 
@@ -193,7 +193,7 @@ func TestDiff_Transform1C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("6:+4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "2:+4:str2", result[0].String())
 
@@ -201,7 +201,7 @@ func TestDiff_Transform1C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("8:+4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:+4:str2", result[0].String())
 }
@@ -212,7 +212,7 @@ func TestDiff_Transform1D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("8:-4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:-4:str2", result[0].String())
 
@@ -220,7 +220,7 @@ func TestDiff_Transform1D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("6:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "2:-4:str2", result[0].String())
 
@@ -229,7 +229,7 @@ func TestDiff_Transform1D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 0, len(result))
 
 	// Test else cases: if overlapping, shorten B by overlap, shift down by LenA - overlap
@@ -237,7 +237,7 @@ func TestDiff_Transform1D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "2:-2:r2", result[0].String())
 }
@@ -247,7 +247,7 @@ func TestDiff_Transform2A(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "8:+4:str2", result[0].String())
 
@@ -255,9 +255,25 @@ func TestDiff_Transform2A(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("0:+4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "15:+4:str2", result[0].String())
+
+	diff1, err = NewDiffFromString("4:+4:str1")
+	require.Nil(t, err)
+	diff2, err = NewDiffFromString("4:+4:str2")
+	require.Nil(t, err)
+	result = diff2.transform(Diffs{diff1}, false)
+	require.Equal(t, 1, len(result))
+	require.Equal(t, "4:+4:str2", result[0].String())
+
+	diff1, err = NewDiffFromString("0:+15:longTestString1")
+	require.Nil(t, err)
+	diff2, err = NewDiffFromString("0:+4:str2")
+	require.Nil(t, err)
+	result = diff2.transform(Diffs{diff1}, false)
+	require.Equal(t, 1, len(result))
+	require.Equal(t, "0:+4:str2", result[0].String())
 }
 
 func TestDiff_Transform2B(t *testing.T) {
@@ -265,7 +281,7 @@ func TestDiff_Transform2B(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "8:-4:str2", result[0].String())
 
@@ -273,7 +289,7 @@ func TestDiff_Transform2B(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("0:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "15:-4:str2", result[0].String())
 }
@@ -283,7 +299,7 @@ func TestDiff_Transform2C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:+4:str2", result[0].String())
 
@@ -291,7 +307,7 @@ func TestDiff_Transform2C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("0:+4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "0:+4:str2", result[0].String())
 }
@@ -302,7 +318,7 @@ func TestDiff_Transform2D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:-15:longTestString2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:-11:TestString2", result[0].String())
 
@@ -311,14 +327,14 @@ func TestDiff_Transform2D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("0:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 0, len(result))
 
 	diff1, err = NewDiffFromString("4:-4:str1")
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 0, len(result))
 }
 
@@ -327,7 +343,7 @@ func TestDiff_Transform3A(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:+4:str2", result[0].String())
 
@@ -335,7 +351,7 @@ func TestDiff_Transform3A(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("0:+15:longTestString2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "0:+15:longTestString2", result[0].String())
 }
@@ -346,7 +362,7 @@ func TestDiff_Transform3B(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:-8:longStr2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 2, len(result))
 	require.Equal(t, "4:-1:l", result[0].String())
 	require.Equal(t, "8:-7:ongStr2", result[1].String())
@@ -356,7 +372,7 @@ func TestDiff_Transform3B(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("0:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "0:-4:str2", result[0].String())
 }
@@ -366,7 +382,7 @@ func TestDiff_Transform3C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:+4:str2", result[0].String())
 
@@ -374,7 +390,7 @@ func TestDiff_Transform3C(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("4:+4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:+4:str2", result[0].String())
 }
@@ -385,7 +401,7 @@ func TestDiff_Transform3D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err := NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result := diff2.transform(Diffs{diff1})
+	result := diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:-2:st", result[0].String())
 
@@ -394,7 +410,7 @@ func TestDiff_Transform3D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:-4:str2", result[0].String())
 
@@ -402,7 +418,7 @@ func TestDiff_Transform3D(t *testing.T) {
 	require.Nil(t, err)
 	diff2, err = NewDiffFromString("4:-4:str2")
 	require.Nil(t, err)
-	result = diff2.transform(Diffs{diff1})
+	result = diff2.transform(Diffs{diff1}, true)
 	require.Equal(t, 1, len(result))
 	require.Equal(t, "4:-4:str2", result[0].String())
 }

--- a/modules/patching/patch.go
+++ b/modules/patching/patch.go
@@ -96,7 +96,7 @@ func (patch *Patch) Undo() *Patch {
 
 // TransformFromString does an Operational Transform against the other patches, creating a set
 // of changes relative to previously applied changes.
-func (patch *Patch) TransformFromString(others []string) (*Patch, error) {
+func (patch *Patch) TransformFromString(others []string, othersHavePrecedence bool) (*Patch, error) {
 	patches := make([]*Patch, len(others))
 
 	for i, v := range others {
@@ -107,12 +107,12 @@ func (patch *Patch) TransformFromString(others []string) (*Patch, error) {
 		patches[i] = patch
 	}
 
-	return patch.Transform(patches), nil
+	return patch.Transform(patches, othersHavePrecedence), nil
 }
 
 // Transform does an Operational Transform against the other patches, creating a set
 // of changes relative to previously applied changes.
-func (patch *Patch) Transform(others []*Patch) *Patch {
+func (patch *Patch) Transform(others []*Patch, othersHavePrecedence bool) *Patch {
 	intermediateDiffs := patch.Changes
 	maxVersionSeen := patch.BaseVersion - 1
 
@@ -120,7 +120,7 @@ func (patch *Patch) Transform(others []*Patch) *Patch {
 		newIntermediateDiffs := Diffs{}
 
 		for _, diff := range intermediateDiffs {
-			newIntermediateDiffs = append(newIntermediateDiffs, diff.transform(otherPatch.Changes)...)
+			newIntermediateDiffs = append(newIntermediateDiffs, diff.transform(otherPatch.Changes, othersHavePrecedence)...)
 		}
 
 		intermediateDiffs = newIntermediateDiffs

--- a/modules/patching/patch_test.go
+++ b/modules/patching/patch_test.go
@@ -186,7 +186,7 @@ func TestPatch_Transform(t *testing.T) {
 	require.Nil(t, err)
 	patch2, err := NewPatchFromString("v0:\n3:-8:deletion,\n3:+6:insert")
 	require.Nil(t, err)
-	newPatch := patch2.Transform([]*Patch{patch1})
+	newPatch := patch2.Transform([]*Patch{patch1}, true)
 	require.Equal(t, 2, len(newPatch.Changes))
 	require.Equal(t, "v2:\n2:-8:deletion,\n2:+6:insert", newPatch.String())
 
@@ -197,7 +197,7 @@ func TestPatch_Transform(t *testing.T) {
 	require.Nil(t, err)
 	patch3, err := NewPatchFromString("v0:\n3:-8:deletion,\n3:+6:insert")
 	require.Nil(t, err)
-	newPatch = patch3.Transform([]*Patch{patch1, patch2})
+	newPatch = patch3.Transform([]*Patch{patch1, patch2}, true)
 	require.Equal(t, 2, len(newPatch.Changes))
 	require.Equal(t, "v3:\n1:-8:deletion,\n1:+6:insert", newPatch.String())
 }


### PR DESCRIPTION
Allows for correct book-keeping and transformation of patches on the client-side by guaranteeing the correctness of returned patches.

Signed-off-by: Benedict Wong <bennydictwong@gmail.com>