### PR TITLE
change dbfs to get a valid couchbase cas, rewire pulling changes to be internal

### DIFF
--- a/modules/datahandling/filerequests_test.go
+++ b/modules/datahandling/filerequests_test.go
@@ -263,7 +263,7 @@ func TestFileChangeRequest_Process(t *testing.T) {
 	}
 
 	// didn't call extra db functions
-	assert.Equal(t, 4, db.FunctionCallCount, "did not call correct number of db functions")
+	assert.Equal(t, 3, db.FunctionCallCount, "did not call correct number of db functions")
 
 	// are we notifying the right people
 	if len(closures) != 2 ||
@@ -313,7 +313,7 @@ func TestFileChangeRequest_Process(t *testing.T) {
 	}
 
 	// didn't call extra db functions
-	assert.Equal(t, 4, db.FunctionCallCount, "did not call correct number of db functions")
+	assert.Equal(t, 3, db.FunctionCallCount, "did not call correct number of db functions")
 
 	// are we notifying the right people
 	if len(closures) != 1 ||
@@ -341,7 +341,7 @@ func TestFilePullRequest_Process(t *testing.T) {
 	db.FileWrite("./", "new file", projectID, []byte{})
 
 	changes := []string{"v0:\n0:+1:a"}
-	db.CBAppendFileChange(fileid, changes, []string{})
+	db.CBAppendFileChange(dbfs.FileMeta{FileID: fileid}, changes)
 
 	req.Resource = "File"
 	req.Method = "Pull"

--- a/modules/dbfs/couchbase.go
+++ b/modules/dbfs/couchbase.go
@@ -169,6 +169,13 @@ func (di *DatabaseImpl) CBAppendFileChange(fileMeta FileMeta, patches []string) 
 		return nil, -1, nil, 0, err
 	}
 
+	if cas == uint64(0) {
+		utils.LogWarn("Couchbase returned a CAS value of 0, optimistic locking is unavailable", utils.LogFields{
+			"cas":  cas,
+			"File": fileMeta,
+		})
+	}
+
 	minVersion := version
 	if len(prevChanges) > 0 {
 		startPatch, err := patching.NewPatchFromString(prevChanges[0])

--- a/modules/dbfs/couchbase_test.go
+++ b/modules/dbfs/couchbase_test.go
@@ -196,7 +196,8 @@ func TestDatabaseImpl_CBAppendFileChange(t *testing.T) {
 	// NOTE: this was added as a need by us changing to dbfs.PullFile
 	di.FileWrite(file.RelativePath, file.Filename, file.ProjectID, []byte{})
 
-	changes, _, err := di.PullChanges(file)
+	changes, _, pulledVersion, _, err := di.PullChanges(file)
+	assert.Equal(t, originalFileVersion, pulledVersion, "failed set up verification")
 
 	transformed, version, missing, lenChanges, err := di.CBAppendFileChange(file, []string{patch3})
 	assert.NoError(t, err, "unexpected error appending changes")
@@ -218,7 +219,8 @@ func TestDatabaseImpl_CBAppendFileChange(t *testing.T) {
 	assert.EqualValues(t, transformed[0], changes[2], "newly inserted change was not correct")
 
 	// Expect AppendFileChange to transform patch4, since it was based on the version created by patch2
-	changes, _, err = di.PullChanges(file)
+	changes, _, pulledVersion, _, err = di.PullChanges(file)
+	assert.Equal(t, pulledVersion, version, "version pulled from the database does not match the one given when appending the change")
 
 	transformed, version, missing, lenChanges, err = di.CBAppendFileChange(file, []string{patch4})
 	assert.NoError(t, err, "unexpected error appending changes")

--- a/modules/dbfs/couchbase_test.go
+++ b/modules/dbfs/couchbase_test.go
@@ -196,9 +196,9 @@ func TestDatabaseImpl_CBAppendFileChange(t *testing.T) {
 	// NOTE: this was added as a need by us changing to dbfs.PullFile
 	di.FileWrite(file.RelativePath, file.Filename, file.ProjectID, []byte{})
 
-	changes, err := di.PullChanges(file)
+	changes, _, err := di.PullChanges(file)
 
-	transformed, version, missing, err := di.CBAppendFileChange(file.FileID, []string{patch3}, changes)
+	transformed, version, missing, lenChanges, err := di.CBAppendFileChange(file, []string{patch3})
 	assert.NoError(t, err, "unexpected error appending changes")
 	assert.Empty(t, missing, "Unexpected missing patches")
 
@@ -209,6 +209,7 @@ func TestDatabaseImpl_CBAppendFileChange(t *testing.T) {
 
 	assert.Empty(t, *raw, "we shouldn't have scrunched")
 	assert.Len(t, changes, 3, "resultant changes not the correct length")
+	assert.Equal(t, len(changes), lenChanges, "did not return correct change count")
 
 	assert.Equal(t, patch1, changes[0], "first change was not correct")
 	assert.Equal(t, patch2, changes[1], "second change was not correct")
@@ -217,9 +218,9 @@ func TestDatabaseImpl_CBAppendFileChange(t *testing.T) {
 	assert.EqualValues(t, transformed[0], changes[2], "newly inserted change was not correct")
 
 	// Expect AppendFileChange to transform patch4, since it was based on the version created by patch2
-	changes, err = di.PullChanges(file)
+	changes, _, err = di.PullChanges(file)
 
-	transformed, version, missing, err = di.CBAppendFileChange(file.FileID, []string{patch4}, changes)
+	transformed, version, missing, lenChanges, err = di.CBAppendFileChange(file, []string{patch4})
 	assert.NoError(t, err, "unexpected error appending changes")
 
 	assert.Len(t, missing, 1, "Unexpected number of missing patches")
@@ -232,6 +233,7 @@ func TestDatabaseImpl_CBAppendFileChange(t *testing.T) {
 
 	assert.Empty(t, *raw, "we shouldn't have scrunched")
 	assert.Len(t, changes, 4, "resultant changes not the correct length")
+	assert.Equal(t, len(changes), lenChanges, "did not return correct change count")
 
 	assert.Equal(t, patch1, changes[0], "first change was not correct")
 	assert.Equal(t, patch2, changes[1], "second change was not correct")

--- a/modules/dbfs/databaseMock.go
+++ b/modules/dbfs/databaseMock.go
@@ -128,10 +128,10 @@ func (dm *DatabaseMock) PullFile(meta FileMeta) (*[]byte, []string, error) {
 }
 
 // PullChanges pulls the changes from the databases
-func (dm *DatabaseMock) PullChanges(meta FileMeta) ([]string, uint64, error) {
+func (dm *DatabaseMock) PullChanges(meta FileMeta) ([]string, uint64, int64, bool, error) {
 	dm.FunctionCallCount++
 	changes := dm.FileChanges[meta.FileID]
-	return changes, 0, nil
+	return changes, 0, dm.FileVersion[meta.FileID], false, nil
 }
 
 // CBAppendFileChange is a mock of the real implementation

--- a/modules/dbfs/databases.go
+++ b/modules/dbfs/databases.go
@@ -22,8 +22,8 @@ type DBFS interface {
 	// PullFile pulls the changes and the file bytes from the databases
 	PullFile(meta FileMeta) (*[]byte, []string, error)
 
-	// PullChanges pulls the changes and file version from the databases
-	PullChanges(meta FileMeta) ([]string, error)
+	// PullChanges pulls the changes from the databases and returns the temporary lock value
+	PullChanges(meta FileMeta) ([]string, uint64, error)
 
 	// Couchbase
 
@@ -41,7 +41,8 @@ type DBFS interface {
 	CBGetFileVersion(fileID int64) (int64, error)
 
 	// CBAppendFileChange mutates the file document with the new change and sets the new version number
-	CBAppendFileChange(fileID int64, changes, prevChanges []string) ([]string, int64, []string, error)
+	// Returns the new version number, the missing patches, the total count of patches tracked, and an error, if any.
+	CBAppendFileChange(file FileMeta, patches []string) ([]string, int64, []string, int, error)
 
 	// MySQL
 

--- a/modules/dbfs/databases.go
+++ b/modules/dbfs/databases.go
@@ -22,8 +22,9 @@ type DBFS interface {
 	// PullFile pulls the changes and the file bytes from the databases
 	PullFile(meta FileMeta) (*[]byte, []string, error)
 
-	// PullChanges pulls the changes from the databases and returns the temporary lock value
-	PullChanges(meta FileMeta) ([]string, uint64, error)
+	// PullChanges pulls the changes from the databases and returns them along with the temporary lock value,
+	// the file version, and the useTemp flag
+	PullChanges(meta FileMeta) ([]string, uint64, int64, bool, error)
 
 	// Couchbase
 

--- a/modules/dbfs/multi_test.go
+++ b/modules/dbfs/multi_test.go
@@ -36,7 +36,7 @@ func setupFile(t *testing.T, baseFile string, baseChanges []string) (*DatabaseIm
 	assert.NoError(t, err, "error writing file to disk")
 
 	for _, change := range baseChanges {
-		_, _, _, err = di.CBAppendFileChange(file.FileID, []string{change}, []string{})
+		_, _, _, _, err = di.CBAppendFileChange(file, []string{change})
 		assert.NoError(t, err, "error appending change to file")
 	}
 
@@ -266,7 +266,7 @@ func nativeErr(t *testing.T, err error) {
 }
 
 func appendChangeToFile(t *testing.T, di *DatabaseImpl, changes []string) {
-	_, _, _, err := di.CBAppendFileChange(file.FileID, changes, []string{})
+	_, _, _, _, err := di.CBAppendFileChange(file, changes)
 	assert.NoError(t, err, "Error while appending more changes")
 }
 


### PR DESCRIPTION
there's apparently a couchbase bug with getting the cas from a call to `cb.bucket.LookupIn(key)`, so it made sense to also rewire how the changes were retrieved as well. 